### PR TITLE
Shops, Shard Goal, Costumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ scripts.txt
 /tests/logs.log
 fuzzParser.py
 
+.vscode
+
 __pycache__

--- a/Items.py
+++ b/Items.py
@@ -94,16 +94,18 @@ def item_factory(
 
 VERY_USEFUL = IC.progression | IC.useful
 ITEM_TABLE: dict[str, HasteItemData] = {
+    "Victory": HasteItemData("Victory", IC.progression, 0, 0),
     "Progressive Shard": HasteItemData("Shard", IC.progression, 1, 9),
     "Shard Shop Filler Item": HasteItemData("Filler", IC.filler, 2, 0),
     "Slomo": HasteItemData("Ability", IC.progression, 3, 1),
     "Grapple": HasteItemData("Ability", IC.progression, 4, 1),
     "Fly": HasteItemData("Ability", IC.progression, 5, 1),
-    "Anti-Spark 100 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 6, 0),
-    "Anti-Spark 250 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 7, 0),
-    "Anti-Spark 500 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 8, 0),
-    "Anti-Spark 750 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 9, 0),
-    "Anti-Spark 1k bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 10, 0),
+    "Anti-Spark 10 bundle": HasteItemData("Anti-Spark Bundle", IC.filler, 6, 0),
+    "Anti-Spark 100 bundle": HasteItemData("Anti-Spark Bundle", IC.filler, 7, 0),
+    "Anti-Spark 250 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 8, 0),
+    "Anti-Spark 500 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 9, 0),
+    "Anti-Spark 750 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 10, 0),
+    "Anti-Spark 1k bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 11, 0),
 }
 
 LOOKUP_ID_TO_NAME: dict[int, str] = {

--- a/Items.py
+++ b/Items.py
@@ -8,7 +8,7 @@ from worlds.AutoWorld import World
 
 class HasteItemData(NamedTuple):
     """
-    This class represents the data for an item in Twilight Princess
+    This class represents the data for an item in Haste
 
     :param type: The type of the item (e.g., "Item", "Poe").
     :param classification: The item's classification (progression, useful, filler).
@@ -25,7 +25,7 @@ class HasteItemData(NamedTuple):
 
 class HasteItem(Item):
     """
-    This class represents an item in Twilight Princess
+    This class represents an item in Haste
 
     :param name: The item's name.
     :param player: The ID of the player who owns the item.
@@ -94,16 +94,16 @@ def item_factory(
 
 VERY_USEFUL = IC.progression | IC.useful
 ITEM_TABLE: dict[str, HasteItemData] = {
-    "Progressive Shard": HasteItemData("Shard", IC.progression, 0, 10),
-    "Shard Shop Filler Item": HasteItemData("Filler", IC.filler, 1, 0),
-    "Slomo": HasteItemData("Ability", IC.progression, 2, 1),
-    "Grapple": HasteItemData("Ability", IC.progression, 3, 1),
-    "Fly": HasteItemData("Ability", IC.progression, 4, 1),
-    "Anti-Spark 100 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 5, 0),
-    "Anti-Spark 250 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 6, 0),
-    "Anti-Spark 500 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 7, 0),
-    "Anti-Spark 750 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 8, 0),
-    "Anti-Spark 1k bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 9, 0),
+    "Progressive Shard": HasteItemData("Shard", IC.progression, 1, 9),
+    "Shard Shop Filler Item": HasteItemData("Filler", IC.filler, 2, 0),
+    "Slomo": HasteItemData("Ability", IC.progression, 3, 1),
+    "Grapple": HasteItemData("Ability", IC.progression, 4, 1),
+    "Fly": HasteItemData("Ability", IC.progression, 5, 1),
+    "Anti-Spark 100 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 6, 0),
+    "Anti-Spark 250 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 7, 0),
+    "Anti-Spark 500 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 8, 0),
+    "Anti-Spark 750 bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 9, 0),
+    "Anti-Spark 1k bundle": HasteItemData("Anti-Spark Bundle", IC.useful, 10, 0),
 }
 
 LOOKUP_ID_TO_NAME: dict[int, str] = {

--- a/Locations.py
+++ b/Locations.py
@@ -62,28 +62,34 @@ for j in range(1, 101):
         code=100 + j, flags=HasteFlag.GlobalShop, shard=1
     )
 
+def none_or_within_shard(goal, rpvl, shard) -> bool:
+    if shard is None: return True
+    if rpvl:
+        return (shard <= goal)
+    return True
 
 def create_locations(world, regions):
 
     # will DEFINITELY need to adjust this once there is more than one region in the game
 
     for location_name, data in LOCATION_TABLE.items():
-        if data.flags == HasteFlag.Always:
-            location = HasteLocation(world.player, location_name, regions["Menu"], data)
-            regions["Menu"].locations.append(location)
-        
-        if data.flags == HasteFlag.Boss:
-            location = HasteLocation(world.player, location_name, regions[f"Shard {data.shard}"], data)
-            regions[f"Shard {data.shard}"].locations.append(location)
-
-        if data.flags == HasteFlag.PerShardShop and world.options.shopsanity == 1:
-            shopnum = int(location_name.split()[-1])
-            if shopnum <= world.options.shopsanity_quantity:
+        if none_or_within_shard(world.options.shard_goal, world.options.remove_post_victory_locations, data.shard):
+            if data.flags == HasteFlag.Always:
+                location = HasteLocation(world.player, location_name, regions["Menu"], data)
+                regions["Menu"].locations.append(location)
+            
+            if data.flags == HasteFlag.Boss:
                 location = HasteLocation(world.player, location_name, regions[f"Shard {data.shard}"], data)
                 regions[f"Shard {data.shard}"].locations.append(location)
 
-        if data.flags == HasteFlag.GlobalShop and world.options.shopsanity == 2:
-            shopnum = int(location_name.split()[-1])
-            if shopnum <= world.options.shopsanity_quantity:
-                location = HasteLocation(world.player, location_name, regions["Shard 1"], data)
-                regions["Shard 1"].locations.append(location)       
+            if data.flags == HasteFlag.PerShardShop and world.options.shopsanity == 1:
+                shopnum = int(location_name.split()[-1])
+                if shopnum <= world.options.shopsanity_quantity:
+                    location = HasteLocation(world.player, location_name, regions[f"Shard {data.shard}"], data)
+                    regions[f"Shard {data.shard}"].locations.append(location)
+
+            if data.flags == HasteFlag.GlobalShop and world.options.shopsanity == 2:
+                shopnum = int(location_name.split()[-1])
+                if shopnum <= world.options.shopsanity_quantity:
+                    location = HasteLocation(world.player, location_name, regions["Shard 1"], data)
+                    regions["Shard 1"].locations.append(location)       

--- a/Locations.py
+++ b/Locations.py
@@ -7,6 +7,8 @@ class HasteFlag(Flag):
     # Define flag types for different categories of checks
     Always = auto()
     Boss = auto()
+    PerShardShop = auto()
+    GlobalShop = auto()
     Unknown = auto()
 
 
@@ -34,39 +36,49 @@ class HasteLocation(Location):
 
 
 LOCATION_TABLE = {
-    "Shard 10 Boss": HasteLocationData(code=None, flags=HasteFlag.Always),
-    "Shard 1 Boss": HasteLocationData(code=1, flags=HasteFlag.Always),
-    "Shard 2 Boss": HasteLocationData(code=2, flags=HasteFlag.Always),
-    "Shard 3 Boss": HasteLocationData(code=3, flags=HasteFlag.Always),
-    "Shard 4 Boss": HasteLocationData(code=4, flags=HasteFlag.Always),
-    "Shard 5 Boss": HasteLocationData(code=5, flags=HasteFlag.Always),
-    "Shard 6 Boss": HasteLocationData(code=6, flags=HasteFlag.Always),
-    "Shard 7 Boss": HasteLocationData(code=7, flags=HasteFlag.Always),
-    "Shard 8 Boss": HasteLocationData(code=8, flags=HasteFlag.Always),
-    "Shard 9 Boss": HasteLocationData(code=9, flags=HasteFlag.Always),
-    "Shard 10 Shop Item": HasteLocationData(code=10, flags=HasteFlag.Always),
-    "Shard 1 Shop Item": HasteLocationData(code=11, flags=HasteFlag.Always),
-    "Shard 2 Shop Item": HasteLocationData(code=12, flags=HasteFlag.Always),
-    "Shard 3 Shop Item": HasteLocationData(code=13, flags=HasteFlag.Always),
-    "Shard 4 Shop Item": HasteLocationData(code=14, flags=HasteFlag.Always),
-    "Shard 5 Shop Item": HasteLocationData(code=15, flags=HasteFlag.Always),
-    "Shard 6 Shop Item": HasteLocationData(code=16, flags=HasteFlag.Always),
-    "Shard 7 Shop Item": HasteLocationData(code=17, flags=HasteFlag.Always),
-    "Shard 8 Shop Item": HasteLocationData(code=18, flags=HasteFlag.Always),
-    "Shard 9 Shop Item": HasteLocationData(code=19, flags=HasteFlag.Always),
-    "Ability Slomo": HasteLocationData(code=20, flags=HasteFlag.Always),
-    "Ability Grapple": HasteLocationData(code=21, flags=HasteFlag.Always),
-    "Ability Fly": HasteLocationData(code=22, flags=HasteFlag.Always),
-    # "Ability Slomo": HasteLocationData(code=0, flags=HasteFlag.Always),
-    # "Ability Grapple": HasteLocationData(code=1, flags=HasteFlag.Always),
-    # "Ability Fly": HasteLocationData(code=2, flags=HasteFlag.Always),
+    "Ability Slomo": HasteLocationData(code=1, flags=HasteFlag.Always),
+    "Ability Grapple": HasteLocationData(code=2, flags=HasteFlag.Always),
+    "Ability Fly": HasteLocationData(code=3, flags=HasteFlag.Always),
 }
 
-# # Per Shard locations
-# for i in range(1, 11):
-#     LOCATION_TABLE[f"Shard {i} Boss"] = HasteLocationData(
-#         code=(9 + i), flags=HasteFlag.Always
-#     )  # 10-19
-#     LOCATION_TABLE[f"Shard {i} Shop Item"] = HasteLocationData(
-#         code=(19 + i), flags=HasteFlag.Always
-#     )  # 20-29
+# Per Shard locations
+for i in range(1, 11):
+    LOCATION_TABLE[f"Shard {i} Boss"] = HasteLocationData(
+        code=9 + i, flags=HasteFlag.Boss
+    )
+
+
+# per-shard shop locations
+for i in range(1,11):
+    for j in range(1, 101):
+        LOCATION_TABLE[f"Shard {i} Shop Item {j}"] = HasteLocationData(
+            code=100 + i*100 + j, flags=HasteFlag.PerShardShop,
+        )
+
+# global shop locations
+for j in range(1, 101):
+    LOCATION_TABLE[f"Global Shop Item {j}"] = HasteLocationData(
+        code=100 + j, flags=HasteFlag.GlobalShop,
+    )
+
+
+def create_locations(world, menu_region):
+
+    # will DEFINITELY need to adjust this once there is more than one region in the game
+
+    for location_name, data in LOCATION_TABLE.items():
+        if data.flags == HasteFlag.Always or data.flags == HasteFlag.Boss:
+            location = HasteLocation(world.player, location_name, menu_region, data)
+            menu_region.locations.append(location)
+
+        if data.flags == HasteFlag.PerShardShop and world.options.shopsanity == 1:
+            shopnum = int(location_name.split()[-1])
+            if shopnum <= world.options.shopsanity_quantity:
+                location = HasteLocation(world.player, location_name, menu_region, data)
+                menu_region.locations.append(location)
+
+        if data.flags == HasteFlag.GlobalShop and world.options.shopsanity == 2:
+            shopnum = int(location_name.split()[-1])
+            if shopnum <= world.options.shopsanity_quantity:
+                location = HasteLocation(world.player, location_name, menu_region, data)
+                menu_region.locations.append(location)       

--- a/Locations.py
+++ b/Locations.py
@@ -15,6 +15,7 @@ class HasteFlag(Flag):
 class HasteLocationData(NamedTuple):
     code: Optional[int]
     flags: HasteFlag
+    shard: Optional[int] = None
 
 
 class HasteLocation(Location):
@@ -44,7 +45,7 @@ LOCATION_TABLE = {
 # Per Shard locations
 for i in range(1, 11):
     LOCATION_TABLE[f"Shard {i} Boss"] = HasteLocationData(
-        code=9 + i, flags=HasteFlag.Boss
+        code=9 + i, flags=HasteFlag.Boss, shard=i
     )
 
 
@@ -52,33 +53,37 @@ for i in range(1, 11):
 for i in range(1,11):
     for j in range(1, 101):
         LOCATION_TABLE[f"Shard {i} Shop Item {j}"] = HasteLocationData(
-            code=100 + i*100 + j, flags=HasteFlag.PerShardShop,
+            code=100 + i*100 + j, flags=HasteFlag.PerShardShop, shard=i
         )
 
 # global shop locations
 for j in range(1, 101):
     LOCATION_TABLE[f"Global Shop Item {j}"] = HasteLocationData(
-        code=100 + j, flags=HasteFlag.GlobalShop,
+        code=100 + j, flags=HasteFlag.GlobalShop, shard=1
     )
 
 
-def create_locations(world, menu_region):
+def create_locations(world, regions):
 
     # will DEFINITELY need to adjust this once there is more than one region in the game
 
     for location_name, data in LOCATION_TABLE.items():
-        if data.flags == HasteFlag.Always or data.flags == HasteFlag.Boss:
-            location = HasteLocation(world.player, location_name, menu_region, data)
-            menu_region.locations.append(location)
+        if data.flags == HasteFlag.Always:
+            location = HasteLocation(world.player, location_name, regions["Menu"], data)
+            regions["Menu"].locations.append(location)
+        
+        if data.flags == HasteFlag.Boss:
+            location = HasteLocation(world.player, location_name, regions[f"Shard {data.shard}"], data)
+            regions[f"Shard {data.shard}"].locations.append(location)
 
         if data.flags == HasteFlag.PerShardShop and world.options.shopsanity == 1:
             shopnum = int(location_name.split()[-1])
             if shopnum <= world.options.shopsanity_quantity:
-                location = HasteLocation(world.player, location_name, menu_region, data)
-                menu_region.locations.append(location)
+                location = HasteLocation(world.player, location_name, regions[f"Shard {data.shard}"], data)
+                regions[f"Shard {data.shard}"].locations.append(location)
 
         if data.flags == HasteFlag.GlobalShop and world.options.shopsanity == 2:
             shopnum = int(location_name.split()[-1])
             if shopnum <= world.options.shopsanity_quantity:
-                location = HasteLocation(world.player, location_name, menu_region, data)
-                menu_region.locations.append(location)       
+                location = HasteLocation(world.player, location_name, regions["Shard 1"], data)
+                regions["Shard 1"].locations.append(location)       

--- a/Regions.py
+++ b/Regions.py
@@ -1,9 +1,11 @@
 import typing
 from typing import Dict
+from math import floor
 
 from BaseClasses import Region, Entrance, MultiWorld
 
-
+# static variable that determines how each shop is segmented region-wise
+SHOP_SEGMENTING = 10
 
 def create_regions(world) -> Dict[str, Region]:
     regions: Dict[str, Region] = {}
@@ -14,15 +16,25 @@ def create_regions(world) -> Dict[str, Region]:
     regions["Menu"] = menu_region
 
     # make regions for the 10 shards, each requiring the X-1 number of progressive shards, and each connecting to the menu
-    # for fill purposes, there is an arguement to be made that Shard 1 locations should be in the Menu/Initial region, since fill prioritizes spheres 0 & 1 and it takes a 'sphere' to go from menu to shard 1
-    s1_region = Region("Shard 1", world.player, world.multiworld)
-    connect(world.player, "Shard 1 Entrance", menu_region, s1_region, lambda state: (True))
-    regions["Shard 1"] = s1_region
-
-    for i in range (2, 11):
-        s2_region = Region(f"Shard {i}", world.player, world.multiworld)
-        connect(world.player, f"Shard {i} Entrance", menu_region, s2_region, lambda state, val=i: state.has("Progressive Shard", world.player, val-1))
-        regions[f"Shard {i}"] = s2_region
+    # for fill purposes, there is an argument to be made that Shard 1 locations should be in the Menu/Initial region, since fill prioritizes spheres 0 & 1 and it takes a 'sphere' to go from menu to shard 1
+    
+    for i in range (1, 11):
+        shard_region = Region(f"Shard {i}", world.player, world.multiworld)
+        if i == 1:
+            connect(world.player, "Shard 1 Entrance", menu_region, shard_region, lambda state: (True))
+            regions["Shard 1"] = shard_region
+        else:
+            connect(world.player, f"Shard {i} Entrance", menu_region, shard_region, lambda state, val=i: state.has("Progressive Shard", world.player, val-1))
+            regions[f"Shard {i}"] = shard_region
+        
+        #subregions for shops, unlocking at SHOP_SEGMENTING-purchase intervals
+        for j in range(1,floor(100/SHOP_SEGMENTING)):
+            shop_region = Region(f"Shard {i} Shop {j}", world.player, world.multiworld)
+            if j == 1:
+                connect(world.player, f"Shard {i} Shop Region {j} Entrance", shard_region, shop_region, lambda state: (True))
+            else:
+                connect(world.player, f"Shard {i} Shop Region {j} Entrance", shard_region, shop_region, lambda state, vali=i, valj=j: state.has(f"Shard{vali}ShopRegion{valj-1}Unlock", world.player))
+            regions[f"Shard {i} Shop {j}"] = shop_region
     
     return regions
 

--- a/Regions.py
+++ b/Regions.py
@@ -1,0 +1,36 @@
+import typing
+from typing import Dict
+
+from BaseClasses import Region, Entrance, MultiWorld
+
+
+
+def create_regions(world) -> Dict[str, Region]:
+    regions: Dict[str, Region] = {}
+
+    # create initial menu region first
+    menu_region = Region(world.origin_region_name, world.player, world.multiworld)
+    world.multiworld.regions.append(menu_region)
+    regions["Menu"] = menu_region
+
+    # make regions for the 10 shards, each requiring the X-1 number of progressive shards, and each connecting to the menu
+    # for fill purposes, there is an arguement to be made that Shard 1 locations should be in the Menu/Initial region, since fill prioritizes spheres 0 & 1 and it takes a 'sphere' to go from menu to shard 1
+    s1_region = Region("Shard 1", world.player, world.multiworld)
+    connect(world.player, "Shard 1 Entrance", menu_region, s1_region, lambda state: (True))
+    regions["Shard 1"] = s1_region
+
+    for i in range (2, 11):
+        s2_region = Region(f"Shard {i}", world.player, world.multiworld)
+        connect(world.player, f"Shard {i} Entrance", menu_region, s2_region, lambda state, val=i: state.has("Progressive Shard", world.player, val-1))
+        regions[f"Shard {i}"] = s2_region
+    
+    return regions
+
+
+def connect(player, connection_name, source_region, target_region, rule):
+    
+    connection = Entrance(player, connection_name, source_region)
+    if rule is not None:
+        connection.access_rule = rule
+    source_region.exits.append(connection)
+    connection.connect(target_region)

--- a/__init__.py
+++ b/__init__.py
@@ -291,6 +291,8 @@ class HasteWorld(World):
             "Shopsanity Quantity": self.options.shopsanity_quantity.value,
             "Shard Goal": self.options.shard_goal.value,
             "Remove Post-Victory Locations": self.options.remove_post_victory_locations.value,
+            "Default Outfit Body": self.options.default_outfit_body.value,
+            "Default Outfit Hat": self.options.default_outfit_hat.value
         }
 
         return slot_data

--- a/__init__.py
+++ b/__init__.py
@@ -151,7 +151,7 @@ class HasteWorld(World):
         Locations.create_locations(self, regions)
         self.multiworld.regions.extend(regions.values())
 
-        self.get_location("Shard 10 Boss").place_locked_item(
+        self.get_location(f"Shard {self.options.shard_goal} Boss").place_locked_item(
             HasteItem(
                 "Victory",
                 self.player,
@@ -241,6 +241,7 @@ class HasteWorld(World):
 
         # Use the same weights for filler items used in the base randomizer.
         filler_consumables = [
+            "Anti-Spark 10 bundle",
             "Anti-Spark 100 bundle",
             "Anti-Spark 250 bundle",
             "Anti-Spark 500 bundle",
@@ -248,11 +249,12 @@ class HasteWorld(World):
             "Anti-Spark 1k bundle",
         ]
         filler_weights = [
-            0,  # 100
-            0,  # 250
-            1,  # 500
-            4,  # 750
-            2,  # 1k
+            10, #10
+            5,  # 100
+            3,  # 250
+            2,  # 500
+            2,  # 750
+            1,  # 1k
         ]
         assert len(filler_consumables) == len(
             filler_weights
@@ -286,7 +288,9 @@ class HasteWorld(World):
             "DeathLink": self.options.death_link.value,
             "ForceReload": self.options.force_reload.value,
             "Shopsanity": self.options.shopsanity.value,
-            "Shopsanity Quantity": self.options.shopsanity_quantity.value
+            "Shopsanity Quantity": self.options.shopsanity_quantity.value,
+            "Shard Goal": self.options.shard_goal.value,
+            "Remove Post-Victory Locations": self.options.remove_post_victory_locations.value,
         }
 
         return slot_data

--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,7 @@ from .Items import (
 )
 from .Locations import LOCATION_TABLE, HasteLocation, HasteFlag, HasteLocationData
 from .options import haste_option_groups, HasteOptions
+from .Regions import create_regions
 
 
 class HasteWeb(WebWorld):
@@ -146,10 +147,9 @@ class HasteWorld(World):
         Then it connects the regions to each other.
         """
 
-        # There are no regions yet
-        menu_region = Region(self.origin_region_name, self.player, self.multiworld)
-        self.multiworld.regions.append(menu_region)
-        Locations.create_locations(self, menu_region)
+        regions = Regions.create_regions(self)
+        Locations.create_locations(self, regions)
+        self.multiworld.regions.extend(regions.values())
 
         self.get_location("Shard 10 Boss").place_locked_item(
             HasteItem(

--- a/__init__.py
+++ b/__init__.py
@@ -140,7 +140,7 @@ class HasteWorld(World):
 
     def create_regions(self) -> None:
         """
-        Create and connect regions for the Twilight Princess world.
+        Create and connect regions for the Haste world.
 
         This method first creates all the regions and adds the locations to them.
         Then it connects the regions to each other.
@@ -149,22 +149,20 @@ class HasteWorld(World):
         # There are no regions yet
         menu_region = Region(self.origin_region_name, self.player, self.multiworld)
         self.multiworld.regions.append(menu_region)
-        for location_name, data in LOCATION_TABLE.items():
-            location = HasteLocation(self.player, location_name, menu_region, data)
-            menu_region.locations.append(location)
+        Locations.create_locations(self, menu_region)
 
         self.get_location("Shard 10 Boss").place_locked_item(
             HasteItem(
                 "Victory",
                 self.player,
-                HasteItemData("Victory", ItemClassification.progression, None, 1),
+                HasteItemData("Victory", ItemClassification.progression, 0, 1),
                 ItemClassification.progression,
             )
         )
 
     def create_items(self) -> None:
         """
-        Create the items for the Twilight Princess world.
+        Create the items for the Haste world.
         """
         generate_itempool(self)
 
@@ -173,7 +171,7 @@ class HasteWorld(World):
     # set_rules() this is where access rules are set
     def set_rules(self) -> None:
         """
-        Set the access rules for the Twilight Princess world.
+        Set the access rules for the Haste world.
         """
         set_location_access_rules(self)
 
@@ -287,6 +285,8 @@ class HasteWorld(World):
         slot_data = {
             "DeathLink": self.options.death_link.value,
             "ForceReload": self.options.force_reload.value,
+            "Shopsanity": self.options.shopsanity.value,
+            "Shopsanity Quantity": self.options.shopsanity_quantity.value
         }
 
         return slot_data

--- a/location_rules.py
+++ b/location_rules.py
@@ -29,10 +29,8 @@ def set_location_access_rules(world: "World"):
             f"Shard {i} Boss", lambda state, val=i: state.has("Progressive Shard", player, val-1)
         )
 
-
-    # TODO: once i figure out regions, make the shops unlock in chunks of 5 (so everything isnt considered sphere 0)
     if world.options.shopsanity == 1:
-        # pershard;
+        # per-shard;
         for i in range(1,world.options.shard_goal + 1 if world.options.remove_post_victory_locations else 11):
             for j in range(1, world.options.shopsanity_quantity+1):
                 set_rule_if_exists(

--- a/location_rules.py
+++ b/location_rules.py
@@ -24,7 +24,7 @@ def set_location_access_rules(world: "World"):
 
     set_rule_if_exists("Shard 1 Boss", lambda state: (True))
 
-    for i in range (2,11):
+    for i in range (2,world.options.shard_goal + 1 if world.options.remove_post_victory_locations else 11):
         set_rule_if_exists(
             f"Shard {i} Boss", lambda state, val=i: state.has("Progressive Shard", player, val-1)
         )
@@ -33,7 +33,7 @@ def set_location_access_rules(world: "World"):
     # TODO: once i figure out regions, make the shops unlock in chunks of 5 (so everything isnt considered sphere 0)
     if world.options.shopsanity == 1:
         # pershard;
-        for i in range(1,11):
+        for i in range(1,world.options.shard_goal + 1 if world.options.remove_post_victory_locations else 11):
             for j in range(1, world.options.shopsanity_quantity+1):
                 set_rule_if_exists(
                     f"Shard {i} Shop Item {j}", lambda state: (True)

--- a/location_rules.py
+++ b/location_rules.py
@@ -14,7 +14,6 @@ def set_location_access_rules(world: "World"):
         # Only worry about logic if the location can be a progress item (and location_name not in world.nonprogress_locations) do not worry bout yet
         assert location_name in LOCATION_TABLE, f"{location_name=}"
         location = world.get_location(location_name)
-
         set_rule(location, rule)
 
     player = world.player
@@ -51,34 +50,31 @@ def set_location_access_rules(world: "World"):
     set_rule_if_exists(
         "Shard 10 Boss", lambda state: state.has("Progressive Shard", player, 9)
     )
-    set_rule_if_exists("Shard 1 Shop Item", lambda state: (True))
-    set_rule_if_exists(
-        "Shard 2 Shop Item", lambda state: state.has("Progressive Shard", player, 1)
-    )
-    set_rule_if_exists(
-        "Shard 3 Shop Item", lambda state: state.has("Progressive Shard", player, 2)
-    )
-    set_rule_if_exists(
-        "Shard 4 Shop Item", lambda state: state.has("Progressive Shard", player, 3)
-    )
-    set_rule_if_exists(
-        "Shard 5 Shop Item", lambda state: state.has("Progressive Shard", player, 4)
-    )
-    set_rule_if_exists(
-        "Shard 6 Shop Item", lambda state: state.has("Progressive Shard", player, 5)
-    )
-    set_rule_if_exists(
-        "Shard 7 Shop Item", lambda state: state.has("Progressive Shard", player, 6)
-    )
-    set_rule_if_exists(
-        "Shard 8 Shop Item", lambda state: state.has("Progressive Shard", player, 7)
-    )
-    set_rule_if_exists(
-        "Shard 9 Shop Item", lambda state: state.has("Progressive Shard", player, 8)
-    )
-    set_rule_if_exists(
-        "Shard 10 Shop Item", lambda state: state.has("Progressive Shard", player, 9)
-    )
+
+
+
+    # TODO: once i figure out regions, make the shops unlock in chunks of 5 (so everything isnt considered sphere 0)
+    # also regions will probably fix the Stupid Python Bug where non-Shard1 shops only become in-logic once all shards are collected
+    if world.options.shopsanity == 1:
+        # pershard;
+        for i in range(1,11):
+            for j in range(1, world.options.shopsanity_quantity+1):
+                if i == 1:
+                    set_rule_if_exists(
+                        f"Shard {i} Shop Item {j}", lambda state: (True)
+                    )
+                else:
+                    set_rule_if_exists(
+                        f"Shard {i} Shop Item {j}", lambda state: state.has("Progressive Shard", player, i-1)
+                    )
+
+    elif world.options.shopsanity == 2:
+        # global
+        for j in range(1, world.options.shopsanity_quantity+1):
+            set_rule_if_exists(
+                f"Global Shop Item {j}", lambda state: (True)
+            )
+
     set_rule_if_exists(
         "Ability Slomo", lambda state: state.has("Progressive Shard", player, 1)
     )

--- a/location_rules.py
+++ b/location_rules.py
@@ -23,50 +23,21 @@ def set_location_access_rules(world: "World"):
     )
 
     set_rule_if_exists("Shard 1 Boss", lambda state: (True))
-    set_rule_if_exists(
-        "Shard 2 Boss", lambda state: state.has("Progressive Shard", player, 1)
-    )
-    set_rule_if_exists(
-        "Shard 3 Boss", lambda state: state.has("Progressive Shard", player, 2)
-    )
-    set_rule_if_exists(
-        "Shard 4 Boss", lambda state: state.has("Progressive Shard", player, 3)
-    )
-    set_rule_if_exists(
-        "Shard 5 Boss", lambda state: state.has("Progressive Shard", player, 4)
-    )
-    set_rule_if_exists(
-        "Shard 6 Boss", lambda state: state.has("Progressive Shard", player, 5)
-    )
-    set_rule_if_exists(
-        "Shard 7 Boss", lambda state: state.has("Progressive Shard", player, 6)
-    )
-    set_rule_if_exists(
-        "Shard 8 Boss", lambda state: state.has("Progressive Shard", player, 7)
-    )
-    set_rule_if_exists(
-        "Shard 9 Boss", lambda state: state.has("Progressive Shard", player, 8)
-    )
-    set_rule_if_exists(
-        "Shard 10 Boss", lambda state: state.has("Progressive Shard", player, 9)
-    )
 
+    for i in range (2,11):
+        set_rule_if_exists(
+            f"Shard {i} Boss", lambda state, val=i: state.has("Progressive Shard", player, val-1)
+        )
 
 
     # TODO: once i figure out regions, make the shops unlock in chunks of 5 (so everything isnt considered sphere 0)
-    # also regions will probably fix the Stupid Python Bug where non-Shard1 shops only become in-logic once all shards are collected
     if world.options.shopsanity == 1:
         # pershard;
         for i in range(1,11):
             for j in range(1, world.options.shopsanity_quantity+1):
-                if i == 1:
-                    set_rule_if_exists(
-                        f"Shard {i} Shop Item {j}", lambda state: (True)
-                    )
-                else:
-                    set_rule_if_exists(
-                        f"Shard {i} Shop Item {j}", lambda state: state.has("Progressive Shard", player, i-1)
-                    )
+                set_rule_if_exists(
+                    f"Shard {i} Shop Item {j}", lambda state: (True)
+                )
 
     elif world.options.shopsanity == 2:
         # global

--- a/options.py
+++ b/options.py
@@ -46,6 +46,26 @@ class ShopsanityQuantity(Range):
     range_end = 100
     default = 25
 
+class ShardGoal(Range):
+    """
+    Determines which shard will be the one that contains your victory condition.
+    """
+
+    display_name = "Shard Goal"
+    range_start = 1
+    range_end = 10
+    default = 10
+
+
+class RemovePostVictoryLocations(Toggle):
+    """
+    Removes any locations in shards that happen after the goal set in Shard Goal.
+    ex: if Shard Goal is set to 7, this will remove any locations in shards 8, 9, and 10
+    """
+    
+    display_name = "Remove Post-Victory Locaitons"
+    default = False
+
 @dataclass
 class HasteOptions(PerGameCommonOptions):
     """
@@ -59,6 +79,8 @@ class HasteOptions(PerGameCommonOptions):
     force_reload: ForceReload
     shopsanity: Shopsanity
     shopsanity_quantity: ShopsanityQuantity
+    shard_goal: ShardGoal
+    remove_post_victory_locations: RemovePostVictoryLocations
 
 
 haste_option_groups: list[OptionGroup] = [

--- a/options.py
+++ b/options.py
@@ -7,6 +7,7 @@ from Options import (
     PerGameCommonOptions,
     StartInventoryPool,
     Toggle,
+    Range,
 )
 
 
@@ -21,6 +22,29 @@ class ForceReload(Toggle):
     display_name = "Force Reload"
     default = False
 
+class Shopsanity(Choice):
+    """
+    Determines how shops are handled, the number of checks per shop is determined by shopsanity_quantity
+    Per-Shard: Shops will contain shopsanity_quantity total checks per Shard
+    Global: Shops will contain shopsanity_quantity total checks for the entire game, regardless of which Shard you are in
+    """
+
+    display_name = "Shopsanity"
+    option_off = 0
+    option_per_shard = 1
+    option_global = 2
+    default = option_off
+
+
+class ShopsanityQuantity(Range):
+    """
+    Determines how many checks are in each shop.
+    """
+
+    display_name = "Shopsanity Quantity"
+    range_start = 1
+    range_end = 100
+    default = 25
 
 @dataclass
 class HasteOptions(PerGameCommonOptions):
@@ -33,6 +57,8 @@ class HasteOptions(PerGameCommonOptions):
 
     # Logic Settings
     force_reload: ForceReload
+    shopsanity: Shopsanity
+    shopsanity_quantity: ShopsanityQuantity
 
 
 haste_option_groups: list[OptionGroup] = [

--- a/options.py
+++ b/options.py
@@ -66,6 +66,28 @@ class RemovePostVictoryLocations(Toggle):
     display_name = "Remove Post-Victory Locaitons"
     default = False
 
+
+
+class DefaultOutfitBody(Range):
+    """
+    Sets Zoe's default costume when loading into the game.
+    """
+
+    display_name = "Default Outfit Body"
+    range_start = 0
+    range_end = 9
+    default = 0
+
+class DefaultOutfitHat(Range):
+    """
+    Sets Zoe's default hat when loading into the game.
+    """
+
+    display_name = "Default Outfit Hat"
+    range_start = 0
+    range_end = 9
+    default = 0
+
 @dataclass
 class HasteOptions(PerGameCommonOptions):
     """
@@ -81,6 +103,8 @@ class HasteOptions(PerGameCommonOptions):
     shopsanity_quantity: ShopsanityQuantity
     shard_goal: ShardGoal
     remove_post_victory_locations: RemovePostVictoryLocations
+    default_outfit_body: DefaultOutfitBody
+    default_outfit_hat: DefaultOutfitHat
 
 
 haste_option_groups: list[OptionGroup] = [
@@ -91,4 +115,12 @@ haste_option_groups: list[OptionGroup] = [
         ],
         start_collapsed=True,
     ),
+    OptionGroup(
+        "Cosmetic Settings",
+        [
+            DefaultOutfitBody,
+            DefaultOutfitHat
+        ],
+        start_collapsed=True,
+    )
 ]

--- a/options.py
+++ b/options.py
@@ -7,6 +7,7 @@ from Options import (
     PerGameCommonOptions,
     StartInventoryPool,
     Toggle,
+    DefaultOnToggle,
     Range,
 )
 
@@ -14,7 +15,7 @@ from Options import (
 # Logic Settings
 class ForceReload(Toggle):
     """
-    When enabled if you recieve an shard unlock in the hub world, the hub will be forced reloaded
+    When enabled if you receive an shard unlock in the hub world, the hub will be forced reloaded
     This includes if you are taking to the captain and other NPC's
     This may cause errors (this is still alpha)
     """
@@ -57,20 +58,22 @@ class ShardGoal(Range):
     default = 10
 
 
-class RemovePostVictoryLocations(Toggle):
+class RemovePostVictoryLocations(DefaultOnToggle):
     """
     Removes any locations in shards that happen after the goal set in Shard Goal.
     ex: if Shard Goal is set to 7, this will remove any locations in shards 8, 9, and 10
     """
     
-    display_name = "Remove Post-Victory Locaitons"
-    default = False
+    display_name = "Remove Post-Victory Locations"
 
 
 
 class DefaultOutfitBody(Range):
     """
     Sets Zoe's default costume when loading into the game.
+    This will not actually unlock the costume from the Fashion Weeboh, and if you change your costume you won't get the "default" back until you reload the game.
+    0 = Courier, 1 = Crispy, 2 = Little Sister, 3 = Supersonic Zoe, 4 = Zoe the Shadow
+    5 = Totally Accurate Zoe, 6 = Flopsy, 7 = Twisted Flopsy, 8 = Weeboh, 9 = Zoe 64 
     """
 
     display_name = "Default Outfit Body"
@@ -81,6 +84,9 @@ class DefaultOutfitBody(Range):
 class DefaultOutfitHat(Range):
     """
     Sets Zoe's default hat when loading into the game.
+    This will not actually unlock the hat from the Fashion Weeboh, and if you change your hat you won't get the "default" back until you reload the game.
+    0 = Courier, 1 = Crispy, 2 = Little Sister, 3 = Supersonic Zoe, 4 = Zoe the Shadow
+    5 = Totally Accurate Zoe, 6 = Flopsy, 7 = Twisted Flopsy, 8 = Weeboh, 9 = Zoe 64 
     """
 
     display_name = "Default Outfit Hat"


### PR DESCRIPTION
- Adds shop rework (`Shopsanity`)
  - Per-Shard: Adds a `ShopsanityQuantity` of checks to each Shard's individual shop
  - Global: Adds a `ShopsanityQuantity` of checks to a global pool of shop purchases, regardless of the Shard it was purchased from
  - Both options are segmented into 10-purchase "blocks", preventing high-purchase counts from being considered an early sphere and ruining the pacing due to early_location fill biases (ie: Global Shop Item 89 is considered sphere 8, instead of sphere 0)
- Adds `ShopsanityQuantity`, allowing for up to 100 purchase locations as defined by the above Shopsanity options
  - 100 locations per-shard is excessive (even for asyncs), but I couldn't justify having a second option for similar mutually-exclusive settings
- Adds `ShardGoal`, allowing for the win condition to be sent from locations other than the Shard 10 Boss
- Adds `RemovePostVictoryLocations`, removing any locations after the assigned 'ShardGoal'
  - ie: If your goal is Shard 7, it removes locations from Shards 8, 9, and 10
- Adds options to assign the default costume for Zoe when first loading the game
  - Does not affect the actual act of purchasing costumes from Fashion Weeboh
- Re-balanced the distribution of the Anti-Spark Bundles, including a new filler 10-spark bundle
  - This is done to account for the vastly larger number of locations due to Shopsanity
  - Will likely be revisted later once more Anti-Spark purchases are added to the AP
- Removed some internal instances of Twilight Princess ;)